### PR TITLE
set i18n in request, with new language value, onPreResponse

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,8 @@ exports.register = function (server, options, next) {
 
         if ( request.session && request.session.get ) {
             language = request.session.get(options.cookie_name) || language;
+
+            request.i18n = i18n(language, options.locale_path);
         }
 
         var response = request.response;


### PR DESCRIPTION
If you create a route to change language value and set it in `session` in your handler, the language was not set in your `view` when the `reply` displayed it.

But, when you refreshed the page again, `onPreHandler` event takes the new value of the language in the `session` and the `view` contains the new translations.

If you want to have new translation in the first call, `i18n` should be set in `onPreResponse` event if the `session` was set in the `handler`.
