### PR TITLE
Change handler to initialize i18n function in request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ exports.register = function (server, options, next) {
     });
 
     //// Insert i18n into view context
-    server.ext("onPreHandler", function (request, reply) {
+    server.ext("onPreAuth", function (request, reply) {
 
         if ( request.session && request.session.get ) {
             language = request.session.get(options.cookie_name) || language;

--- a/test/index.js
+++ b/test/index.js
@@ -34,7 +34,7 @@ describe("Hapi Basic i18n", function () {
         server.register({
             register: require("../"),
             options: {
-                locale_path: "../test/languages",
+                locale_path: "./test/languages",
                 default_language: "EN",
                 available_languages: ["EN", "TR"]
             }
@@ -79,7 +79,7 @@ describe("Hapi Basic i18n", function () {
         server.register({
             register: require("../"),
             options: {
-                locale_path: "../test/languages",
+                locale_path: "./test/languages",
                 default_language: "EN",
                 available_languages: ["TR"]
             }
@@ -114,7 +114,7 @@ describe("Hapi Basic i18n", function () {
         server.register({
             register: require("../"),
             options: {
-                locale_path: "../test/languages",
+                locale_path: "./test/languages",
                 default_language: "TR",
                 available_languages: ["EN", "TR"]
             }
@@ -165,7 +165,7 @@ describe("Hapi Basic i18n", function () {
         server.register({
             register: require("../"),
             options: {
-                locale_path: "../test/languages",
+                locale_path: "./test/languages",
                 default_language: "EN",
                 available_languages: ["EN", "TR"]
             }


### PR DESCRIPTION
Hello,

To have `i18n` functionality in all [request lifecycle](http://hapijs.com/api#request-lifecycle), `handler` must be set on **`onPreAuth`** and not on `onPreHandler` extension point.

If `handler` is on `onPreHandler` extension endpoint, all elements between `onPreAuth` and `onPreHandler` can use `i18n` functionality.

By exemple, when an error occurred in `Validate payload` process, request jump directly to `onPreResponse` extension endpoint without pass into `onPreHandler` so `request` doesn't have `i18n` function set.

If you create a custom handler for `failAction` to display custom page after `Validate payload` failure, `request` doesn't have `i18n` function set too.

I've tested with the plugin with `handler` on **`onPreAuth`** extension endpoint and all is fine because all the plugin needs it's cookie parsing to know if language must be changed and at this endpoint it was done.

If you are agree with me, can you merge ASAP because I use your plugin and I would like to have the fix.

Thanks,

Best regards.
