### PR TITLE
change handler from `onPreAuth` to `onPostAuth`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ exports.register = function (server, options, next) {
     });
 
     //// Insert i18n into view context
-    server.ext("onPreAuth", function (request, reply) {
+    server.ext("onPostAuth", function (request, reply) {
 
         if ( request.session && request.session.get ) {
             language = request.session.get(options.cookie_name) || language;


### PR DESCRIPTION
In Pull Request #3, I've change handler from `onPreHandler` to **`onPreAuth`** and it's work fine but if you want to have a custom handler on `onPreAuth` to set new language in session to use it in code and not in template, it doesn't work because plugin executes first his handler.

Example:
- Create custom handler on `onPreAuth` to set new language in session
- Call a route which contains translation process
- `hapi-basic-i18n` handler on `onPreAuth` is called with **old language in session** and `i18n` is set in `request`
- **custom handler** is call on `onPreAuth` and set **new language in session**
- use `request.i18n` in your route handler to translate data in your code but language uses is the **old**
- set translated data in `context` of your view
- `reply.view(tpl, context)`
-  `hapi-basic-i18n` handler on `onPreAuth` is called with **new language in session** and `i18n` is set in `request` and functionality is set in `context` view
- display `context` in the template => data are in **old language**
- translate data in the template with `{{i18n data}}` => data is in **new language**

To fix it, handler must be on **`onPostAuth`** and after that you can do same example:
- Create custom handler on `onPreAuth` to set new language in session
- Call a route which contains translation process
- **custom handler** is call on `onPreAuth` and set **new language in session**
- `hapi-basic-i18n` handler on `onPostAuth` is called with **new language in session** and `i18n` is set in `request`
- use `request.i18n` in your route handler to translate data in your code and language uses is the **new**
- set translated data in `context` of your view
- `reply.view(tpl, context)`
-  `hapi-basic-i18n` handler on `onPreAuth` is called with **new language in session** and `i18n` is set in `request` and functionality is set in `context` view
- display `context` in the template => data are in **new language**
- translate data in the template with `{{i18n data}}` => data is in **new language**

If error occurred in `auth` process and you want to `reply` custom page, set an handler on `onPreResponse` and `i18n` will be ok because it was set in `onPostAuth` extension endpoint.

Apologies for the confusion in my previous pull request, worked fine but not answered all features.

If you are OK, can you merge ASAP and publish new version on NPM.

Thanks,

Best regards.
