### PR TITLE
Declare language as local var to prevent leaking between requests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,9 @@ exports.register = function (server, options, next) {
             request.i18n = i18n(language, options.locale_path);
         }
         else {
-            console.log(language + " => part is not in the available languages: " + options.available_languages.join(","));
+            if (language) {
+                console.log(language + " => part is not in the available languages: " + options.available_languages.join(","));
+            }
             request.i18n = i18n(options.default_language, options.locale_path);
         }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,7 @@ exports.register = function (server, options, next) {
 
     //// Insert i18n into view context
     server.ext("onPostAuth", function (request, reply) {
+        var language = null;
 
         if (request.params["language"]) {
             language = request.params["language"];


### PR DESCRIPTION
Because `language` isn't declared as a local var, the value from the previous time this fn was run will still be there, so if the code doesn't fall into the `if` block on line 43 or the `else if` on 46, then the value from the last request will be used, which means if a user from France looks at a page, then immediately an American user (who maybe doesn't explicitly set `language` param) makes a request, they'll get a French translation.

This PR should fix that.